### PR TITLE
Implement basic like/dislike reactions

### DIFF
--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Review;
+use App\Models\Reaction;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ReactionController extends Controller
+{
+    public function store(Request $request, Review $review)
+    {
+        $data = $request->validate([
+            'type' => 'required|in:like,dislike',
+        ]);
+
+        $reaction = Reaction::where('user_id', Auth::id())
+            ->where('review_id', $review->id)
+            ->first();
+
+        if ($reaction && $reaction->type === $data['type']) {
+            $reaction->delete();
+        } else {
+            Reaction::updateOrCreate(
+                ['user_id' => Auth::id(), 'review_id' => $review->id],
+                ['type' => $data['type']]
+            );
+        }
+
+        return redirect()->back();
+    }
+}

--- a/app/Http/Controllers/ReviewObjectController.php
+++ b/app/Http/Controllers/ReviewObjectController.php
@@ -24,7 +24,7 @@ class ReviewObjectController extends Controller
         // Загружаем отзывы сразу с пользователями (авторами)
         $object->load([
             'reviews' => function($q) {
-                $q->with('user')->orderBy('created_at', 'desc');
+                $q->with(['user', 'reactions'])->orderBy('created_at', 'desc');
             }
         ]);
 

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Reaction extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'review_id',
+        'type',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function review()
+    {
+        return $this->belongsTo(Review::class);
+    }
+}

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Reaction;
 
 class Review extends Model
 {
@@ -35,5 +36,13 @@ class Review extends Model
     public function comments()
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /**
+     * Reactions (likes/dislikes) for this review.
+     */
+    public function reactions()
+    {
+        return $this->hasMany(Reaction::class);
     }
 }

--- a/database/migrations/2025_06_05_000005_create_reactions_table.php
+++ b/database/migrations/2025_06_05_000005_create_reactions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('review_id')->constrained()->onDelete('cascade');
+            $table->string('type');
+            $table->timestamps();
+            $table->unique(['user_id', 'review_id'], 'user_review_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reactions');
+    }
+};

--- a/resources/views/objects/show.blade.php
+++ b/resources/views/objects/show.blade.php
@@ -62,6 +62,22 @@
                     <div class="text-gray-700 leading-relaxed">
                         {!! nl2br(e($review->content)) !!}
                     </div>
+                    <div class="mt-2 flex items-center text-sm">
+                        <form action="{{ route('reviews.react', $review) }}" method="POST" class="mr-2">
+                            @csrf
+                            <input type="hidden" name="type" value="like">
+                            <button type="submit" class="text-green-600 hover:underline">
+                                👍 {{ $review->reactions->where('type', 'like')->count() }}
+                            </button>
+                        </form>
+                        <form action="{{ route('reviews.react', $review) }}" method="POST">
+                            @csrf
+                            <input type="hidden" name="type" value="dislike">
+                            <button type="submit" class="text-red-600 hover:underline">
+                                👎 {{ $review->reactions->where('type', 'dislike')->count() }}
+                            </button>
+                        </form>
+                    </div>
                 </div>
             @empty
                 <p class="text-gray-600">Пока нет ни одного отзыва. Станьте первым!</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\ReviewObjectController;
 use App\Http\Controllers\ReviewCommentController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ReactionController;
 
 /*
 |--------------------------------------------------------------------------
@@ -28,6 +29,11 @@ Route::post('/objects/{slug}/reviews', [ReviewObjectController::class, 'storeRev
 Route::post('/reviews/{review}/comments', [ReviewCommentController::class, 'store'])
      ->middleware('auth')
      ->name('reviews.comments.store');
+
+// 4.1) Добавление лайка/дизлайка к отзыву
+Route::post('/reviews/{review}/react', [ReactionController::class, 'store'])
+     ->middleware('auth')
+     ->name('reviews.react');
 
 // 5) Страница “Помощь”
 Route::get('/help', function () {

--- a/tests/Feature/ReactionTest.php
+++ b/tests/Feature/ReactionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User;
+use App\Models\Review;
+use App\Models\ReviewObject;
+use App\Models\Category;
+use App\Models\Reaction;
+
+it('allows user to like a review', function () {
+    $user = User::factory()->create();
+    $category = Category::create(['title' => 'Test']);
+    $object = ReviewObject::create([
+        'category_id' => $category->id,
+        'title' => 'Obj',
+        'slug' => 'obj',
+    ]);
+    $review = Review::create([
+        'user_id' => $user->id,
+        'review_object_id' => $object->id,
+        'content' => 'text',
+        'rating' => 5,
+    ]);
+
+    actingAs($user)
+        ->post(route('reviews.react', $review), ['type' => 'like'])
+        ->assertRedirect();
+
+    expect(Reaction::where('user_id', $user->id)->where('review_id', $review->id)->where('type', 'like')->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- add `Reaction` model and migration
- create `ReactionController` for toggling like/dislike
- register route and load reactions with reviews
- show like/dislike buttons and counts in object view
- add Pest test for reaction logic

## Testing
- `composer install` *(fails: command not found)*
- `php artisan test --filter ReactionTest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840025038788328868a8e4460b40b2b