### PR TITLE
Implement simple admin panel

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class CategoryController extends Controller
+{
+    public function index(): View
+    {
+        $categories = Category::paginate(15);
+        return view('admin.categories.index', compact('categories'));
+    }
+
+    public function create(): View
+    {
+        return view('admin.categories.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+        Category::create($data);
+        return redirect()->route('admin.categories.index');
+    }
+
+    public function edit(Category $category): View
+    {
+        return view('admin.categories.edit', compact('category'));
+    }
+
+    public function update(Request $request, Category $category): RedirectResponse
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+        $category->update($data);
+        return redirect()->route('admin.categories.index');
+    }
+
+    public function destroy(Category $category): RedirectResponse
+    {
+        $category->delete();
+        return redirect()->route('admin.categories.index');
+    }
+}

--- a/app/Http/Controllers/Admin/CommentController.php
+++ b/app/Http/Controllers/Admin/CommentController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Comment;
+use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class CommentController extends Controller
+{
+    public function index(): View
+    {
+        $comments = Comment::with(['user', 'review'])->paginate(15);
+        return view('admin.comments.index', compact('comments'));
+    }
+
+    public function edit(Comment $comment): View
+    {
+        return view('admin.comments.edit', compact('comment'));
+    }
+
+    public function update(Request $request, Comment $comment): RedirectResponse
+    {
+        $data = $request->validate([
+            'content' => 'required|string',
+        ]);
+        $comment->update($data);
+        return redirect()->route('admin.comments.index');
+    }
+
+    public function destroy(Comment $comment): RedirectResponse
+    {
+        $comment->delete();
+        return redirect()->route('admin.comments.index');
+    }
+}

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Review;
+use App\Models\Comment;
+use App\Models\User;
+use App\Models\Category;
+use Illuminate\View\View;
+
+class DashboardController extends Controller
+{
+    public function index(): View
+    {
+        $stats = [
+            'reviews' => Review::count(),
+            'comments' => Comment::count(),
+            'users' => User::count(),
+            'categories' => Category::count(),
+        ];
+
+        return view('admin.dashboard', compact('stats'));
+    }
+}

--- a/app/Http/Controllers/Admin/ReactionController.php
+++ b/app/Http/Controllers/Admin/ReactionController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Reaction;
+use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
+
+class ReactionController extends Controller
+{
+    public function index(): View
+    {
+        $reactions = Reaction::with(['user', 'review'])->paginate(15);
+        return view('admin.reactions.index', compact('reactions'));
+    }
+
+    public function destroy(Reaction $reaction): RedirectResponse
+    {
+        $reaction->delete();
+        return redirect()->route('admin.reactions.index');
+    }
+}

--- a/app/Http/Controllers/Admin/ReviewController.php
+++ b/app/Http/Controllers/Admin/ReviewController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Review;
+use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ReviewController extends Controller
+{
+    public function index(): View
+    {
+        $reviews = Review::with(['user', 'object'])->paginate(15);
+        return view('admin.reviews.index', compact('reviews'));
+    }
+
+    public function edit(Review $review): View
+    {
+        return view('admin.reviews.edit', compact('review'));
+    }
+
+    public function update(Request $request, Review $review): RedirectResponse
+    {
+        $data = $request->validate([
+            'content' => 'required|string',
+            'rating' => 'required|integer|min:1|max:5',
+        ]);
+        $review->update($data);
+        return redirect()->route('admin.reviews.index');
+    }
+
+    public function destroy(Review $review): RedirectResponse
+    {
+        $review->delete();
+        return redirect()->route('admin.reviews.index');
+    }
+}

--- a/app/Http/Controllers/Admin/ReviewObjectController.php
+++ b/app/Http/Controllers/Admin/ReviewObjectController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\ReviewObject;
+use App\Models\Category;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+use Illuminate\Support\Str;
+
+class ReviewObjectController extends Controller
+{
+    public function index(): View
+    {
+        $objects = ReviewObject::with('category')->paginate(15);
+        return view('admin.objects.index', compact('objects'));
+    }
+
+    public function create(): View
+    {
+        $categories = Category::all();
+        return view('admin.objects.create', compact('categories'));
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'category_id' => 'required|exists:categories,id',
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+        $data['slug'] = Str::slug($data['title']);
+        ReviewObject::create($data);
+        return redirect()->route('admin.objects.index');
+    }
+
+    public function edit(ReviewObject $object): View
+    {
+        $categories = Category::all();
+        return view('admin.objects.edit', compact('object', 'categories'));
+    }
+
+    public function update(Request $request, ReviewObject $object): RedirectResponse
+    {
+        $data = $request->validate([
+            'category_id' => 'required|exists:categories,id',
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+        $data['slug'] = Str::slug($data['title']);
+        $object->update($data);
+        return redirect()->route('admin.objects.index');
+    }
+
+    public function destroy(ReviewObject $object): RedirectResponse
+    {
+        $object->delete();
+        return redirect()->route('admin.objects.index');
+    }
+}

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function index(): View
+    {
+        $users = User::paginate(15);
+        return view('admin.users.index', compact('users'));
+    }
+
+    public function edit(User $user): View
+    {
+        return view('admin.users.edit', compact('user'));
+    }
+
+    public function update(Request $request, User $user): RedirectResponse
+    {
+        $data = $request->validate([
+            'role' => 'required|in:user,moderator,admin',
+        ]);
+        $user->update($data);
+        return redirect()->route('admin.users.index');
+    }
+
+    public function destroy(User $user): RedirectResponse
+    {
+        $user->delete();
+        return redirect()->route('admin.users.index');
+    }
+}

--- a/app/Http/Middleware/IsAdmin.php
+++ b/app/Http/Middleware/IsAdmin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class IsAdmin
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        if (!$user || $user->role !== 'admin') {
+            abort(403);
+        }
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,6 +15,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
         // если есть другие поля, добавьте их сюда
     ];
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
+            'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+            'is_admin' => \App\Http\Middleware\IsAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'user',
         ];
     }
 

--- a/database/migrations/2025_06_06_000006_add_role_to_users_table.php
+++ b/database/migrations/2025_06_06_000006_add_role_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('user');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -1,0 +1,15 @@
+<x-admin-layout>
+    <h1 class="text-xl font-bold mb-4">Create Category</h1>
+    <form method="POST" action="{{ route('admin.categories.store') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label class="block">Title</label>
+            <input type="text" name="title" class="border rounded w-full" required>
+        </div>
+        <div>
+            <label class="block">Description</label>
+            <textarea name="description" class="border rounded w-full"></textarea>
+        </div>
+        <button class="bg-indigo-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+    </form>
+</x-admin-layout>

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -1,0 +1,16 @@
+<x-admin-layout>
+    <h1 class="text-xl font-bold mb-4">Edit Category</h1>
+    <form method="POST" action="{{ route('admin.categories.update', $category) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="block">Title</label>
+            <input type="text" name="title" class="border rounded w-full" value="{{ $category->title }}" required>
+        </div>
+        <div>
+            <label class="block">Description</label>
+            <textarea name="description" class="border rounded w-full">{{ $category->description }}</textarea>
+        </div>
+        <button class="bg-indigo-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+    </form>
+</x-admin-layout>

--- a/resources/views/admin/categories/index.blade.php
+++ b/resources/views/admin/categories/index.blade.php
@@ -1,0 +1,32 @@
+<x-admin-layout>
+    <div class="flex justify-between mb-4">
+        <h1 class="text-xl font-bold">Categories</h1>
+        <a href="{{ route('admin.categories.create') }}" class="text-blue-500">Create</a>
+    </div>
+    <table class="min-w-full bg-white">
+        <thead>
+            <tr>
+                <th class="px-4 py-2">ID</th>
+                <th class="px-4 py-2">Title</th>
+                <th class="px-4 py-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach($categories as $category)
+            <tr class="border-t">
+                <td class="px-4 py-2">{{ $category->id }}</td>
+                <td class="px-4 py-2">{{ $category->title }}</td>
+                <td class="px-4 py-2 space-x-2">
+                    <a href="{{ route('admin.categories.edit', $category) }}" class="text-indigo-600">Edit</a>
+                    <form action="{{ route('admin.categories.destroy', $category) }}" method="POST" class="inline">
+                        @csrf
+                        @method('DELETE')
+                        <button class="text-red-600" onclick="return confirm('Delete?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+    {{ $categories->links() }}
+</x-admin-layout>

--- a/resources/views/admin/comments/edit.blade.php
+++ b/resources/views/admin/comments/edit.blade.php
@@ -1,0 +1,12 @@
+<x-admin-layout>
+    <h1 class="text-xl font-bold mb-4">Edit Comment</h1>
+    <form method="POST" action="{{ route('admin.comments.update', $comment) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="block">Content</label>
+            <textarea name="content" class="border rounded w-full">{{ $comment->content }}</textarea>
+        </div>
+        <button class="bg-indigo-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+    </form>
+</x-admin-layout>

--- a/resources/views/admin/comments/index.blade.php
+++ b/resources/views/admin/comments/index.blade.php
@@ -1,0 +1,32 @@
+<x-admin-layout>
+    @php use Illuminate\Support\Str; @endphp
+    <h1 class="text-xl font-bold mb-4">Comments</h1>
+    <table class="min-w-full bg-white">
+        <thead>
+            <tr>
+                <th class="px-4 py-2">ID</th>
+                <th class="px-4 py-2">User</th>
+                <th class="px-4 py-2">Review</th>
+                <th class="px-4 py-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach($comments as $comment)
+            <tr class="border-t">
+                <td class="px-4 py-2">{{ $comment->id }}</td>
+                <td class="px-4 py-2">{{ $comment->user->name }}</td>
+                <td class="px-4 py-2">{{ Str::limit($comment->review->content, 30) }}</td>
+                <td class="px-4 py-2 space-x-2">
+                    <a href="{{ route('admin.comments.edit', $comment) }}" class="text-indigo-600">Edit</a>
+                    <form action="{{ route('admin.comments.destroy', $comment) }}" method="POST" class="inline">
+                        @csrf
+                        @method('DELETE')
+                        <button class="text-red-600" onclick="return confirm('Delete?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+    {{ $comments->links() }}
+</x-admin-layout>

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,9 @@
+<x-admin-layout>
+    <h1 class="text-2xl font-bold mb-4">Dashboard</h1>
+    <div class="grid grid-cols-2 gap-4">
+        <div class="p-4 bg-white rounded shadow">Reviews: {{ $stats['reviews'] }}</div>
+        <div class="p-4 bg-white rounded shadow">Comments: {{ $stats['comments'] }}</div>
+        <div class="p-4 bg-white rounded shadow">Users: {{ $stats['users'] }}</div>
+        <div class="p-4 bg-white rounded shadow">Categories: {{ $stats['categories'] }}</div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/objects/create.blade.php
+++ b/resources/views/admin/objects/create.blade.php
@@ -1,0 +1,23 @@
+<x-admin-layout>
+    <h1 class="text-xl font-bold mb-4">Create Object</h1>
+    <form method="POST" action="{{ route('admin.objects.store') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label class="block">Title</label>
+            <input type="text" name="title" class="border rounded w-full" required>
+        </div>
+        <div>
+            <label class="block">Category</label>
+            <select name="category_id" class="border rounded w-full">
+                @foreach($categories as $category)
+                    <option value="{{ $category->id }}">{{ $category->title }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label class="block">Description</label>
+            <textarea name="description" class="border rounded w-full"></textarea>
+        </div>
+        <button class="bg-indigo-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+    </form>
+</x-admin-layout>

--- a/resources/views/admin/objects/edit.blade.php
+++ b/resources/views/admin/objects/edit.blade.php
@@ -1,0 +1,24 @@
+<x-admin-layout>
+    <h1 class="text-xl font-bold mb-4">Edit Object</h1>
+    <form method="POST" action="{{ route('admin.objects.update', $object) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="block">Title</label>
+            <input type="text" name="title" class="border rounded w-full" value="{{ $object->title }}" required>
+        </div>
+        <div>
+            <label class="block">Category</label>
+            <select name="category_id" class="border rounded w-full">
+                @foreach($categories as $category)
+                    <option value="{{ $category->id }}" @selected($object->category_id == $category->id)>{{ $category->title }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label class="block">Description</label>
+            <textarea name="description" class="border rounded w-full">{{ $object->description }}</textarea>
+        </div>
+        <button class="bg-indigo-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+    </form>
+</x-admin-layout>

--- a/resources/views/admin/objects/index.blade.php
+++ b/resources/views/admin/objects/index.blade.php
@@ -1,0 +1,34 @@
+<x-admin-layout>
+    <div class="flex justify-between mb-4">
+        <h1 class="text-xl font-bold">Objects</h1>
+        <a href="{{ route('admin.objects.create') }}" class="text-blue-500">Create</a>
+    </div>
+    <table class="min-w-full bg-white">
+        <thead>
+            <tr>
+                <th class="px-4 py-2">ID</th>
+                <th class="px-4 py-2">Title</th>
+                <th class="px-4 py-2">Category</th>
+                <th class="px-4 py-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach($objects as $object)
+            <tr class="border-t">
+                <td class="px-4 py-2">{{ $object->id }}</td>
+                <td class="px-4 py-2">{{ $object->title }}</td>
+                <td class="px-4 py-2">{{ $object->category->title }}</td>
+                <td class="px-4 py-2 space-x-2">
+                    <a href="{{ route('admin.objects.edit', $object) }}" class="text-indigo-600">Edit</a>
+                    <form action="{{ route('admin.objects.destroy', $object) }}" method="POST" class="inline">
+                        @csrf
+                        @method('DELETE')
+                        <button class="text-red-600" onclick="return confirm('Delete?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+    {{ $objects->links() }}
+</x-admin-layout>

--- a/resources/views/admin/reactions/index.blade.php
+++ b/resources/views/admin/reactions/index.blade.php
@@ -1,0 +1,33 @@
+<x-admin-layout>
+    @php use Illuminate\Support\Str; @endphp
+    <h1 class="text-xl font-bold mb-4">Reactions</h1>
+    <table class="min-w-full bg-white">
+        <thead>
+            <tr>
+                <th class="px-4 py-2">ID</th>
+                <th class="px-4 py-2">User</th>
+                <th class="px-4 py-2">Review</th>
+                <th class="px-4 py-2">Type</th>
+                <th class="px-4 py-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach($reactions as $reaction)
+            <tr class="border-t">
+                <td class="px-4 py-2">{{ $reaction->id }}</td>
+                <td class="px-4 py-2">{{ $reaction->user->name }}</td>
+                <td class="px-4 py-2">{{ Str::limit($reaction->review->content, 30) }}</td>
+                <td class="px-4 py-2">{{ $reaction->type }}</td>
+                <td class="px-4 py-2">
+                    <form action="{{ route('admin.reactions.destroy', $reaction) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button class="text-red-600" onclick="return confirm('Delete?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+    {{ $reactions->links() }}
+</x-admin-layout>

--- a/resources/views/admin/reviews/edit.blade.php
+++ b/resources/views/admin/reviews/edit.blade.php
@@ -1,0 +1,16 @@
+<x-admin-layout>
+    <h1 class="text-xl font-bold mb-4">Edit Review</h1>
+    <form method="POST" action="{{ route('admin.reviews.update', $review) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="block">Content</label>
+            <textarea name="content" class="border rounded w-full">{{ $review->content }}</textarea>
+        </div>
+        <div>
+            <label class="block">Rating</label>
+            <input type="number" name="rating" value="{{ $review->rating }}" class="border rounded w-full">
+        </div>
+        <button class="bg-indigo-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+    </form>
+</x-admin-layout>

--- a/resources/views/admin/reviews/index.blade.php
+++ b/resources/views/admin/reviews/index.blade.php
@@ -1,0 +1,33 @@
+<x-admin-layout>
+    <h1 class="text-xl font-bold mb-4">Reviews</h1>
+    <table class="min-w-full bg-white">
+        <thead>
+            <tr>
+                <th class="px-4 py-2">ID</th>
+                <th class="px-4 py-2">User</th>
+                <th class="px-4 py-2">Object</th>
+                <th class="px-4 py-2">Rating</th>
+                <th class="px-4 py-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach($reviews as $review)
+            <tr class="border-t">
+                <td class="px-4 py-2">{{ $review->id }}</td>
+                <td class="px-4 py-2">{{ $review->user->name }}</td>
+                <td class="px-4 py-2">{{ $review->object->title }}</td>
+                <td class="px-4 py-2">{{ $review->rating }}</td>
+                <td class="px-4 py-2 space-x-2">
+                    <a href="{{ route('admin.reviews.edit', $review) }}" class="text-indigo-600">Edit</a>
+                    <form action="{{ route('admin.reviews.destroy', $review) }}" method="POST" class="inline">
+                        @csrf
+                        @method('DELETE')
+                        <button class="text-red-600" onclick="return confirm('Delete?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+    {{ $reviews->links() }}
+</x-admin-layout>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -1,0 +1,16 @@
+<x-admin-layout>
+    <h1 class="text-xl font-bold mb-4">Edit User</h1>
+    <form method="POST" action="{{ route('admin.users.update', $user) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label class="block">Role</label>
+            <select name="role" class="border rounded w-full">
+                <option value="user" @selected($user->role==='user')>user</option>
+                <option value="moderator" @selected($user->role==='moderator')>moderator</option>
+                <option value="admin" @selected($user->role==='admin')>admin</option>
+            </select>
+        </div>
+        <button class="bg-indigo-600 text-white px-4 py-2 rounded" type="submit">Save</button>
+    </form>
+</x-admin-layout>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,0 +1,33 @@
+<x-admin-layout>
+    <h1 class="text-xl font-bold mb-4">Users</h1>
+    <table class="min-w-full bg-white">
+        <thead>
+            <tr>
+                <th class="px-4 py-2">ID</th>
+                <th class="px-4 py-2">Name</th>
+                <th class="px-4 py-2">Email</th>
+                <th class="px-4 py-2">Role</th>
+                <th class="px-4 py-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach($users as $user)
+            <tr class="border-t">
+                <td class="px-4 py-2">{{ $user->id }}</td>
+                <td class="px-4 py-2">{{ $user->name }}</td>
+                <td class="px-4 py-2">{{ $user->email }}</td>
+                <td class="px-4 py-2">{{ $user->role }}</td>
+                <td class="px-4 py-2 space-x-2">
+                    <a href="{{ route('admin.users.edit', $user) }}" class="text-indigo-600">Edit</a>
+                    <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline">
+                        @csrf
+                        @method('DELETE')
+                        <button class="text-red-600" onclick="return confirm('Delete?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+    {{ $users->links() }}
+</x-admin-layout>

--- a/resources/views/components/admin-layout.blade.php
+++ b/resources/views/components/admin-layout.blade.php
@@ -1,0 +1,5 @@
+@props(['title' => ''])
+
+<x-layouts.admin>
+    {{ $slot }}
+</x-layouts.admin>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>Admin</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="font-sans antialiased">
+<div class="min-h-screen bg-gray-100 flex">
+    <aside class="w-64 bg-white border-r">
+        <div class="p-4 font-bold">Admin</div>
+        <nav class="p-4 space-y-2">
+            <a href="{{ route('admin.dashboard') }}" class="block">Dashboard</a>
+            <a href="{{ route('admin.users.index') }}" class="block">Users</a>
+            <a href="{{ route('admin.categories.index') }}" class="block">Categories</a>
+            <a href="{{ route('admin.objects.index') }}" class="block">Objects</a>
+            <a href="{{ route('admin.reviews.index') }}" class="block">Reviews</a>
+            <a href="{{ route('admin.comments.index') }}" class="block">Comments</a>
+            <a href="{{ route('admin.reactions.index') }}" class="block">Reactions</a>
+        </nav>
+    </aside>
+    <main class="flex-1 p-6">
+        {{ $slot }}
+    </main>
+</div>
+</body>
+</html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -66,6 +66,11 @@
                             <x-dropdown-link :href="route('profile.edit')">
                                 {{ __('Профиль') }}
                             </x-dropdown-link>
+                            @if(Auth::user() && Auth::user()->role === 'admin')
+                                <x-dropdown-link :href="route('admin.dashboard')">
+                                    {{ __('Админ') }}
+                                </x-dropdown-link>
+                            @endif
 
                             <div class="border-t border-gray-100"></div>
 
@@ -150,6 +155,11 @@
                     <x-responsive-nav-link :href="route('profile.edit')">
                         {{ __('Профиль') }}
                     </x-responsive-nav-link>
+                    @if(Auth::user() && Auth::user()->role === 'admin')
+                        <x-responsive-nav-link :href="route('admin.dashboard')">
+                            {{ __('Админ') }}
+                        </x-responsive-nav-link>
+                    @endif
 
                     <form method="POST" action="{{ route('logout') }}">
                         @csrf

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\DashboardController;
+use App\Http\Controllers\Admin\CategoryController;
+use App\Http\Controllers\Admin\ReviewObjectController;
+use App\Http\Controllers\Admin\ReviewController;
+use App\Http\Controllers\Admin\CommentController;
+use App\Http\Controllers\Admin\ReactionController;
+use App\Http\Controllers\Admin\UserController;
+
+Route::middleware(['auth', 'is_admin'])->prefix('admin')->name('admin.')->group(function () {
+    Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
+    Route::resource('categories', CategoryController::class);
+    Route::resource('objects', ReviewObjectController::class);
+    Route::resource('reviews', ReviewController::class)->except(['create','store','show']);
+    Route::resource('comments', CommentController::class)->except(['create','store','show']);
+    Route::resource('reactions', ReactionController::class)->only(['index','destroy']);
+    Route::resource('users', UserController::class)->except(['create','store','show']);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,3 +60,4 @@ Route::middleware(['auth'])->group(function () {
 
 // 8) В самом низу подключаем маршруты аутентификации Breeze (login/register/logout)
 require __DIR__.'/auth.php';
+require __DIR__.'/admin.php';

--- a/tests/Feature/AdminAccessTest.php
+++ b/tests/Feature/AdminAccessTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User;
+
+it('denies access for non admin', function () {
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->get('/admin')
+        ->assertStatus(403);
+});
+
+it('allows access for admin', function () {
+    $user = User::factory()->create(['role' => 'admin']);
+
+    actingAs($user)
+        ->get('/admin')
+        ->assertOk();
+});
+
+it('can create category', function () {
+    $user = User::factory()->create(['role' => 'admin']);
+
+    actingAs($user)
+        ->post('/admin/categories', ['title' => 'Tech'])
+        ->assertRedirect('/admin/categories');
+
+    expect(\App\Models\Category::where('title', 'Tech')->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- add admin role to users and middleware
- configure middleware aliases
- build admin controllers, routes, and views
- create Blade layout for admin pages
- expose admin link in navigation when user is admin
- basic feature tests for admin access

## Testing
- `php artisan test --compact` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684010c25b048328aa052cae6f99da8d