### PR TITLE
Implement basic messaging system

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class MessageController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+        $conversations = Conversation::where('user_one_id', $user->id)
+            ->orWhere('user_two_id', $user->id)
+            ->with('messages', 'userOne', 'userTwo')
+            ->get();
+
+        return view('messages.index', compact('conversations'));
+    }
+
+    public function start(User $user)
+    {
+        $auth = Auth::user();
+        $conversation = Conversation::where(function ($q) use ($auth, $user) {
+            $q->where('user_one_id', $auth->id)->where('user_two_id', $user->id);
+        })->orWhere(function ($q) use ($auth, $user) {
+            $q->where('user_one_id', $user->id)->where('user_two_id', $auth->id);
+        })->first();
+
+        if (!$conversation) {
+            $conversation = Conversation::create([
+                'user_one_id' => $auth->id,
+                'user_two_id' => $user->id,
+            ]);
+        }
+
+        return redirect()->route('messages.show', $conversation);
+    }
+
+    public function show(Conversation $conversation)
+    {
+        $user = Auth::user();
+        if ($conversation->user_one_id !== $user->id && $conversation->user_two_id !== $user->id) {
+            abort(403);
+        }
+
+        $messages = $conversation->messages()->orderBy('created_at')->get();
+        $conversation->messages()
+            ->where('sender_id', '!=', $user->id)
+            ->where('is_read', false)
+            ->update(['is_read' => true]);
+
+        return view('messages.show', compact('conversation', 'messages'));
+    }
+
+    public function store(Conversation $conversation, Request $request)
+    {
+        $user = Auth::user();
+        if ($conversation->user_one_id !== $user->id && $conversation->user_two_id !== $user->id) {
+            abort(403);
+        }
+
+        $data = $request->validate([
+            'message' => 'required|string',
+        ]);
+
+        $conversation->messages()->create([
+            'sender_id' => $user->id,
+            'message' => $data['message'],
+            'is_read' => false,
+        ]);
+
+        return redirect()->route('messages.show', $conversation);
+    }
+}

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Conversation extends Model
+{
+    protected $fillable = [
+        'user_one_id',
+        'user_two_id',
+    ];
+
+    public function userOne(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_one_id');
+    }
+
+    public function userTwo(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_two_id');
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(Message::class);
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Message extends Model
+{
+    protected $fillable = [
+        'conversation_id',
+        'sender_id',
+        'message',
+        'is_read',
+    ];
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    public function sender(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Conversation;
 
 class User extends Authenticatable
 {
@@ -42,5 +43,14 @@ class User extends Authenticatable
     public function comments()
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /**
+     * Все беседы пользователя.
+     */
+    public function conversations()
+    {
+        return Conversation::where('user_one_id', $this->id)
+            ->orWhere('user_two_id', $this->id);
     }
 }

--- a/database/migrations/2025_06_07_000007_create_conversations_table.php
+++ b/database/migrations/2025_06_07_000007_create_conversations_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('conversations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_one_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('user_two_id')->constrained('users')->onDelete('cascade');
+            $table->timestamps();
+            $table->unique(['user_one_id', 'user_two_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('conversations');
+    }
+};

--- a/database/migrations/2025_06_07_000008_create_messages_table.php
+++ b/database/migrations/2025_06_07_000008_create_messages_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('conversation_id')->constrained()->onDelete('cascade');
+            $table->foreignId('sender_id')->constrained('users')->onDelete('cascade');
+            $table->text('message');
+            $table->boolean('is_read')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -1,0 +1,34 @@
+{{-- resources/views/messages/index.blade.php --}}
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Мои беседы') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-8">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8 space-y-4">
+            @forelse ($conversations as $conv)
+                @php
+                    $other = $conv->user_one_id === auth()->id() ? $conv->userTwo : $conv->userOne;
+                    $last = $conv->messages->last();
+                    $unread = $conv->messages->where('sender_id', '!=', auth()->id())->where('is_read', false)->count();
+                @endphp
+                <a href="{{ route('messages.show', $conv) }}" class="block p-4 bg-white rounded shadow hover:bg-gray-50">
+                    <div class="font-medium">{{ $other->name }}</div>
+                    @if ($last)
+                        <div class="text-sm text-gray-600">
+                            {{ \Illuminate\Support\Str::limit($last->message, 50) }}
+                            <span class="ml-2 text-xs text-gray-400">{{ $last->created_at->diffForHumans() }}</span>
+                            @if ($unread)
+                                <span class="ml-2 text-red-500">({{ $unread }})</span>
+                            @endif
+                        </div>
+                    @endif
+                </a>
+            @empty
+                <p class="text-gray-600">У вас нет бесед.</p>
+            @endforelse
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -1,0 +1,29 @@
+{{-- resources/views/messages/show.blade.php --}}
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ $conversation->user_one_id === auth()->id() ? $conversation->userTwo->name : $conversation->userOne->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-8">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white p-4 rounded shadow space-y-4">
+                @foreach ($messages as $msg)
+                    <div class="{{ $msg->sender_id === auth()->id() ? 'text-right' : 'text-left' }}">
+                        <div class="inline-block px-3 py-2 rounded {{ $msg->sender_id === auth()->id() ? 'bg-indigo-100' : 'bg-gray-100' }}">
+                            <p>{{ $msg->message }}</p>
+                            <span class="text-xs text-gray-500">{{ $msg->created_at->format('d.m.Y H:i') }}</span>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+
+            <form method="POST" action="{{ route('messages.store', $conversation) }}" class="mt-4 flex space-x-2">
+                @csrf
+                <input type="text" name="message" class="flex-1 border-gray-300 rounded" required>
+                <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Отправить</button>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -128,8 +128,14 @@
             const tabContents = document.querySelectorAll('.tab-content');
 
             function showTab(tabId) {
+                const contentId = tabId.startsWith('tab-') ? tabId : `tab-${tabId}`;
+                const contentEl = document.getElementById(contentId);
+                if (!contentEl) {
+                    return; // защита от попытки открыть несуществующую вкладку
+                }
+
                 tabContents.forEach(tc => tc.classList.add('hidden'));
-                document.getElementById(tabId).classList.remove('hidden');
+                contentEl.classList.remove('hidden');
 
                 tabLinks.forEach(link => {
                     link.classList.remove('text-indigo-600', 'border-b-2', 'border-indigo-600');
@@ -148,8 +154,12 @@
                 });
             });
 
-            // Показать первую вкладку по умолчанию
-            if (tabLinks.length > 0) {
+            // Определяем вкладку из URL ?tab=
+            const urlParams = new URLSearchParams(window.location.search);
+            const initialTab = urlParams.get('tab');
+            if (initialTab) {
+                showTab(initialTab);
+            } else if (tabLinks.length > 0) {
                 showTab(tabLinks[0].getAttribute('data-tab'));
             }
         });

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,6 +56,12 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    // 7.3) Обмен сообщениями
+    Route::get('/messages', [\App\Http\Controllers\MessageController::class, 'index'])->name('messages.index');
+    Route::post('/messages/start/{user}', [\App\Http\Controllers\MessageController::class, 'start'])->name('messages.start');
+    Route::get('/messages/{conversation}', [\App\Http\Controllers\MessageController::class, 'show'])->name('messages.show');
+    Route::post('/messages/{conversation}', [\App\Http\Controllers\MessageController::class, 'store'])->name('messages.store');
 });
 
 // 8) В самом низу подключаем маршруты аутентификации Breeze (login/register/logout)

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\User;
+use App\Models\Conversation;
+use App\Models\Message;
+
+// Guest cannot access messages
+it('guest cannot access messages', function () {
+    $this->get('/messages')->assertRedirect('/login');
+});
+
+// User can start new conversation
+it('user can start new conversation', function () {
+    $u1 = User::factory()->create();
+    $u2 = User::factory()->create();
+
+    actingAs($u1)
+        ->post(route('messages.start', $u2))
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('conversations', [
+        'user_one_id' => $u1->id,
+        'user_two_id' => $u2->id,
+    ]);
+});
+
+// User can send message
+it('user can send message', function () {
+    $u1 = User::factory()->create();
+    $u2 = User::factory()->create();
+    $conv = Conversation::create(['user_one_id' => $u1->id, 'user_two_id' => $u2->id]);
+
+    actingAs($u1)
+        ->post(route('messages.store', $conv), ['message' => 'hello'])
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('messages', [
+        'conversation_id' => $conv->id,
+        'sender_id' => $u1->id,
+        'message' => 'hello',
+    ]);
+});
+
+// User cannot view other conversation
+it('user cannot view other conversation', function () {
+    $u1 = User::factory()->create();
+    $u2 = User::factory()->create();
+    $u3 = User::factory()->create();
+    $conv = Conversation::create(['user_one_id' => $u1->id, 'user_two_id' => $u2->id]);
+
+    actingAs($u3)
+        ->get(route('messages.show', $conv))
+        ->assertStatus(403);
+});


### PR DESCRIPTION
## Summary
- fix profile tab switching script to avoid errors and allow ?tab= parameter
- add `Conversation` and `Message` models
- create migrations for conversations and messages
- implement `MessageController` with basic CRUD methods
- register message routes
- add blade views for conversation listing and viewing
- add user method to fetch conversations
- add feature tests for messaging

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684019be1b98832880383363fa9f01bb