### PR TITLE
Fix admin comment/reaction view PHP blocks

### DIFF
--- a/resources/views/admin/comments/index.blade.php
+++ b/resources/views/admin/comments/index.blade.php
@@ -1,5 +1,4 @@
 <x-admin-layout>
-    @php use Illuminate\Support\Str; @endphp
     <h1 class="text-xl font-bold mb-4">Comments</h1>
     <table class="min-w-full bg-white">
         <thead>
@@ -15,7 +14,7 @@
             <tr class="border-t">
                 <td class="px-4 py-2">{{ $comment->id }}</td>
                 <td class="px-4 py-2">{{ $comment->user->name }}</td>
-                <td class="px-4 py-2">{{ Str::limit($comment->review->content, 30) }}</td>
+                <td class="px-4 py-2">{{ \Illuminate\Support\Str::limit($comment->review->content, 30) }}</td>
                 <td class="px-4 py-2 space-x-2">
                     <a href="{{ route('admin.comments.edit', $comment) }}" class="text-indigo-600">Edit</a>
                     <form action="{{ route('admin.comments.destroy', $comment) }}" method="POST" class="inline">

--- a/resources/views/admin/reactions/index.blade.php
+++ b/resources/views/admin/reactions/index.blade.php
@@ -1,5 +1,4 @@
 <x-admin-layout>
-    @php use Illuminate\Support\Str; @endphp
     <h1 class="text-xl font-bold mb-4">Reactions</h1>
     <table class="min-w-full bg-white">
         <thead>
@@ -16,7 +15,7 @@
             <tr class="border-t">
                 <td class="px-4 py-2">{{ $reaction->id }}</td>
                 <td class="px-4 py-2">{{ $reaction->user->name }}</td>
-                <td class="px-4 py-2">{{ Str::limit($reaction->review->content, 30) }}</td>
+                <td class="px-4 py-2">{{ \Illuminate\Support\Str::limit($reaction->review->content, 30) }}</td>
                 <td class="px-4 py-2">{{ $reaction->type }}</td>
                 <td class="px-4 py-2">
                     <form action="{{ route('admin.reactions.destroy', $reaction) }}" method="POST">


### PR DESCRIPTION
## Summary
- fix syntax in admin comment view
- fix syntax in admin reaction view

## Testing
- `apt-get update`
- `apt-get install -y php-cli`
- `./vendor/bin/phpunit -v` *(fails: No such file)*

------
https://chatgpt.com/codex/tasks/task_e_68401f85d9f8832897cb03483a248bf9