### PR TITLE
Implement user messaging with live updates

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
 use App\Models\Review;
 use App\Models\Comment;
+use App\Models\User;
 
 class ProfileController extends Controller
 {
@@ -71,5 +72,10 @@ class ProfileController extends Controller
         $request->session()->regenerateToken();
 
         return Redirect::to('/');
+    }
+
+    public function show(User $user): View
+    {
+        return view('profile.show', compact('user'));
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,3 +5,5 @@ import Alpine from 'alpinejs';
 window.Alpine = Alpine;
 
 Alpine.start();
+
+import './messages';

--- a/resources/js/messages.js
+++ b/resources/js/messages.js
@@ -1,0 +1,41 @@
+import axios from 'axios';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('messages-container');
+    if (!container) return;
+
+    const convId = container.dataset.conversation;
+    const userId = parseInt(container.dataset.userId);
+    let lastTs = container.dataset.lastTimestamp;
+
+    const addMessage = (msg) => {
+        const div = document.createElement('div');
+        div.className = msg.sender_id === userId ? 'text-right' : 'text-left';
+        div.innerHTML = `<div class="inline-block px-3 py-2 rounded ${msg.sender_id === userId ? 'bg-indigo-100' : 'bg-gray-100'}"><p>${msg.message}</p><span class="text-xs text-gray-500">${msg.created_at_formatted}</span></div>`;
+        container.appendChild(div);
+        container.scrollTop = container.scrollHeight;
+        lastTs = msg.created_at;
+    };
+
+    const fetchUpdates = async () => {
+        try {
+            const { data } = await axios.get(`/messages/${convId}/updates`, { params: { after: lastTs } });
+            data.forEach(addMessage);
+        } catch (e) { }
+    };
+
+    setInterval(fetchUpdates, 5000);
+
+    const form = document.getElementById('message-form');
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const input = form.querySelector('input[name="message"]');
+        const text = input.value.trim();
+        if (!text) return;
+        try {
+            const { data } = await axios.post(`/messages/${convId}`, { message: text });
+            addMessage(data);
+            input.value = '';
+        } catch (e) { }
+    });
+});

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -66,6 +66,9 @@
                             <x-dropdown-link :href="route('profile.edit')">
                                 {{ __('Профиль') }}
                             </x-dropdown-link>
+                            <x-dropdown-link :href="route('messages.index')">
+                                {{ __('Сообщения') }}
+                            </x-dropdown-link>
                             @if(Auth::user() && Auth::user()->role === 'admin')
                                 <x-dropdown-link :href="route('admin.dashboard')">
                                     {{ __('Админ') }}
@@ -154,6 +157,9 @@
                 <div class="mt-3 space-y-1">
                     <x-responsive-nav-link :href="route('profile.edit')">
                         {{ __('Профиль') }}
+                    </x-responsive-nav-link>
+                    <x-responsive-nav-link :href="route('messages.index')">
+                        {{ __('Сообщения') }}
                     </x-responsive-nav-link>
                     @if(Auth::user() && Auth::user()->role === 'admin')
                         <x-responsive-nav-link :href="route('admin.dashboard')">

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -8,7 +8,11 @@
 
     <div class="py-8">
         <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white p-4 rounded shadow space-y-4">
+            <div id="messages-container"
+                 data-conversation="{{ $conversation->id }}"
+                 data-user-id="{{ auth()->id() }}"
+                 data-last-timestamp="{{ optional($messages->last())->created_at }}"
+                 class="bg-white p-4 rounded shadow space-y-4 overflow-y-auto max-h-96">
                 @foreach ($messages as $msg)
                     <div class="{{ $msg->sender_id === auth()->id() ? 'text-right' : 'text-left' }}">
                         <div class="inline-block px-3 py-2 rounded {{ $msg->sender_id === auth()->id() ? 'bg-indigo-100' : 'bg-gray-100' }}">
@@ -19,7 +23,7 @@
                 @endforeach
             </div>
 
-            <form method="POST" action="{{ route('messages.store', $conversation) }}" class="mt-4 flex space-x-2">
+            <form id="message-form" method="POST" action="{{ route('messages.store', $conversation) }}" class="mt-4 flex space-x-2">
                 @csrf
                 <input type="text" name="message" class="flex-1 border-gray-300 rounded" required>
                 <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Отправить</button>

--- a/resources/views/objects/show.blade.php
+++ b/resources/views/objects/show.blade.php
@@ -46,9 +46,13 @@
                 <div class="bg-white shadow rounded-lg p-4 mb-4">
                     <div class="flex justify-between items-center mb-1">
                         {{-- Имя автора --}}
-                        <span class="font-medium text-gray-800">
-                            {{ $review->user->name ?? 'Аноним' }}
-                        </span>
+                        @if($review->user)
+                            <a href="{{ route('users.show', $review->user) }}" class="font-medium text-gray-800 hover:underline">
+                                {{ $review->user->name }}
+                            </a>
+                        @else
+                            <span class="font-medium text-gray-800">Аноним</span>
+                        @endif
                         {{-- Оценка --}}
                         <span class="text-yellow-500 font-semibold">
                             {{ $review->rating }} ★

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -21,6 +21,9 @@
                     <a href="#tab-comments" class="tab-link text-gray-600 hover:text-indigo-600 font-medium" data-tab="comments">
                         Мои комментарии ({{ $myComments->count() }})
                     </a>
+                    <a href="{{ route('messages.index') }}" class="text-gray-600 hover:text-indigo-600 font-medium">
+                        Сообщения
+                    </a>
                 </nav>
             </div>
 

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -1,0 +1,21 @@
+{{-- resources/views/profile/show.blade.php --}}
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ $user->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-8">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            @auth
+                @if (auth()->id() !== $user->id)
+                    <form method="POST" action="{{ route('messages.start', $user) }}">
+                        @csrf
+                        <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Написать сообщение</button>
+                    </form>
+                @endif
+            @endauth
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,9 @@ Route::get('/promo', function () {
     return view('promo');
 })->name('promo');
 
+// Публичный профиль пользователя
+Route::get('/users/{user}', [ProfileController::class, 'show'])->name('users.show');
+
 // 7) Защищённые маршруты (личный кабинет, дашборд)
 Route::middleware(['auth'])->group(function () {
     // 7.1) Дашборд
@@ -61,6 +64,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/messages', [\App\Http\Controllers\MessageController::class, 'index'])->name('messages.index');
     Route::post('/messages/start/{user}', [\App\Http\Controllers\MessageController::class, 'start'])->name('messages.start');
     Route::get('/messages/{conversation}', [\App\Http\Controllers\MessageController::class, 'show'])->name('messages.show');
+    Route::get('/messages/{conversation}/updates', [\App\Http\Controllers\MessageController::class, 'updates'])->name('messages.updates');
     Route::post('/messages/{conversation}', [\App\Http\Controllers\MessageController::class, 'store'])->name('messages.store');
 });
 


### PR DESCRIPTION
## Summary
- allow starting conversations from a public profile page
- show author links on reviews
- add "Сообщения" links in navigation and profile
- implement JSON updates and AJAX polling for chats
- add messages JavaScript module

## Testing
- `npm install`
- `npm run build`
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684020c79b208328acab6a3743fb2b39