### PR TITLE
Enable image attachments

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -66,6 +66,7 @@ class MessageController extends Controller
 
         $data = $request->validate([
             'message' => 'required|string',
+            'image'   => 'nullable|image|max:2048',
         ]);
 
         $message = $conversation->messages()->create([
@@ -73,6 +74,12 @@ class MessageController extends Controller
             'message' => $data['message'],
             'is_read' => false,
         ]);
+
+        if ($request->hasFile('image')) {
+            $path = $request->file('image')->store('messages', 'public');
+            $message->image_path = $path;
+            $message->save();
+        }
         if ($request->expectsJson()) {
             return response()->json([
                 'id' => $message->id,

--- a/app/Http/Controllers/ReviewCommentController.php
+++ b/app/Http/Controllers/ReviewCommentController.php
@@ -28,17 +28,24 @@ class ReviewCommentController extends Controller
         // Валидация контента комментария
         $data = $request->validate([
             'content' => 'required|string|min:3',
+            'image'   => 'nullable|image|max:2048',
         ], [
             'content.required' => 'Поле комментария не может быть пустым.',
             'content.min'      => 'Комментарий слишком короткий.',
         ]);
 
         // Создаём комментарий
-        Comment::create([
+        $comment = Comment::create([
             'user_id'   => Auth::id(),
             'review_id' => $review->id,
             'content'   => $data['content'],
         ]);
+
+        if ($request->hasFile('image')) {
+            $path = $request->file('image')->store('comments', 'public');
+            $comment->image_path = $path;
+            $comment->save();
+        }
 
         return redirect()
             ->route('objects.show', $review->object->slug)

--- a/app/Http/Controllers/ReviewObjectController.php
+++ b/app/Http/Controllers/ReviewObjectController.php
@@ -45,6 +45,7 @@ class ReviewObjectController extends Controller
         $validated = $request->validate([
             'content' => 'required|string|min:10|max:2000',
             'rating'  => 'required|integer|min:1|max:5',
+            'image'   => 'nullable|image|max:2048',
         ]);
 
         // Сохраняем новый отзыв
@@ -55,6 +56,12 @@ class ReviewObjectController extends Controller
             'rating'            => $validated['rating'],
         ]);
         $review->save();
+
+        if ($request->hasFile('image')) {
+            $path = $request->file('image')->store('reviews', 'public');
+            $review->image_path = $path;
+            $review->save();
+        }
 
         // Пересчёт среднего рейтинга и количества отзывов
         $allRatings = $object->reviews()->pluck('rating')->toArray();

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -10,6 +10,7 @@ class Comment extends Model
         'user_id',
         'review_id',
         'content',
+        'image_path',
     ];
 
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -12,6 +12,7 @@ class Message extends Model
         'sender_id',
         'message',
         'is_read',
+        'image_path',
     ];
 
     public function conversation(): BelongsTo

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -12,6 +12,7 @@ class Review extends Model
         'review_object_id',
         'content',
         'rating',
+        'image_path',
     ];
 
     /**

--- a/database/migrations/2025_06_08_100000_add_image_path_to_reviews.php
+++ b/database/migrations/2025_06_08_100000_add_image_path_to_reviews.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->string('image_path')->nullable()->after('content');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->dropColumn('image_path');
+        });
+    }
+};

--- a/database/migrations/2025_06_08_100001_add_image_path_to_comments.php
+++ b/database/migrations/2025_06_08_100001_add_image_path_to_comments.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->string('image_path')->nullable()->after('content');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropColumn('image_path');
+        });
+    }
+};

--- a/database/migrations/2025_06_08_100002_add_image_path_to_messages.php
+++ b/database/migrations/2025_06_08_100002_add_image_path_to_messages.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->string('image_path')->nullable()->after('message');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropColumn('image_path');
+        });
+    }
+};

--- a/resources/views/components/app-layout.blade.php
+++ b/resources/views/components/app-layout.blade.php
@@ -7,7 +7,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{-- Подключаем скомпилированные стили Breeze/Vite (TailwindCSS + Alpine) --}}
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @if (file_exists(public_path('build/manifest.json')))
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @endif
 
     {{-- Если у тебя есть собственный CSS (style.css с фиксацией хедера, футером и т. д.), подключаем его тоже --}}
     <link rel="stylesheet" href="{{ asset('css/style.css') }}">

--- a/resources/views/components/layouts/admin.blade.php
+++ b/resources/views/components/layouts/admin.blade.php
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Admin</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @if (file_exists(public_path('build/manifest.json')))
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @endif
 </head>
 <body class="font-sans antialiased">
 <div class="min-h-screen bg-gray-100 flex">

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Admin</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @if (file_exists(public_path('build/manifest.json')))
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @endif
 </head>
 <body class="font-sans antialiased">
 <div class="min-h-screen bg-gray-100 flex">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,7 +12,9 @@
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @if (file_exists(public_path('build/manifest.json')))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endif
     </head>
     <body class="font-sans antialiased">
         <div class="min-h-screen bg-gray-100">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -12,7 +12,9 @@
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @if (file_exists(public_path('build/manifest.json')))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endif
     </head>
     <body class="font-sans text-gray-900 antialiased">
         <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -17,15 +17,19 @@
                     <div class="{{ $msg->sender_id === auth()->id() ? 'text-right' : 'text-left' }}">
                         <div class="inline-block px-3 py-2 rounded {{ $msg->sender_id === auth()->id() ? 'bg-indigo-100' : 'bg-gray-100' }}">
                             <p>{{ $msg->message }}</p>
+                            @if($msg->image_path)
+                                <img src="{{ Storage::url($msg->image_path) }}" alt="image" class="mt-2 max-w-xs rounded">
+                            @endif
                             <span class="text-xs text-gray-500">{{ $msg->created_at->format('d.m.Y H:i') }}</span>
                         </div>
                     </div>
                 @endforeach
             </div>
 
-            <form id="message-form" method="POST" action="{{ route('messages.store', $conversation) }}" class="mt-4 flex space-x-2">
+            <form id="message-form" method="POST" action="{{ route('messages.store', $conversation) }}" class="mt-4 flex space-x-2" enctype="multipart/form-data">
                 @csrf
                 <input type="text" name="message" class="flex-1 border-gray-300 rounded" required>
+                <input type="file" name="image" accept="image/*">
                 <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Отправить</button>
             </form>
         </div>

--- a/resources/views/objects/show.blade.php
+++ b/resources/views/objects/show.blade.php
@@ -66,6 +66,11 @@
                     <div class="text-gray-700 leading-relaxed">
                         {!! nl2br(e($review->content)) !!}
                     </div>
+                    @if($review->image_path)
+                        <div class="mt-2">
+                            <img src="{{ Storage::url($review->image_path) }}" alt="image" class="max-w-xs rounded">
+                        </div>
+                    @endif
                     <div class="mt-2 flex items-center text-sm">
                         <form action="{{ route('reviews.react', $review) }}" method="POST" class="mr-2">
                             @csrf
@@ -112,7 +117,7 @@
                         </div>
                     @endif
 
-                    <form action="{{ route('objects.reviews.store', ['slug' => $object->slug]) }}" method="POST">
+                    <form action="{{ route('objects.reviews.store', ['slug' => $object->slug]) }}" method="POST" enctype="multipart/form-data">
                         @csrf
 
                         {{-- Поле “Оценка” --}}
@@ -137,10 +142,15 @@
                             <label for="content" class="block text-sm font-medium text-gray-700 mb-1">
                                 Текст отзыва <span class="text-red-500">*</span>
                             </label>
-                            <textarea id="content" name="content" rows="5" required
+                        <textarea id="content" name="content" rows="5" required
                                       class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm
                                              focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
                                       placeholder="Поделитесь своим опытом…">{{ old('content') }}</textarea>
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="image" class="block text-sm font-medium text-gray-700 mb-1">Изображение</label>
+                            <input type="file" name="image" id="image" accept="image/*">
                         </div>
 
                         <div class="flex justify-end">

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -72,6 +72,9 @@
                             </div>
                             <div class="mt-2 text-yellow-500 font-semibold">★ {{ $review->rating }}</div>
                             <p class="mt-1 text-gray-700">{{ \Illuminate\Support\Str::limit($review->content, 120) }}</p>
+                            @if($review->image_path)
+                                <img src="{{ Storage::url($review->image_path) }}" alt="image" class="mt-2 max-w-xs rounded">
+                            @endif
                         </div>
                     @empty
                         <p class="text-gray-600 italic">Отзывов пока нет.</p>
@@ -87,6 +90,9 @@
                                 <span class="text-gray-500 text-sm">{{ $comment->created_at->format('d.m.Y H:i') }}</span>
                             </div>
                             <p class="mt-2 text-gray-700">{{ \Illuminate\Support\Str::limit($comment->content, 120) }}</p>
+                            @if($comment->image_path)
+                                <img src="{{ Storage::url($comment->image_path) }}" alt="image" class="mt-2 max-w-xs rounded">
+                            @endif
                         </div>
                     @empty
                         <p class="text-gray-600 italic">Комментариев пока нет.</p>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,3 +45,10 @@ function something()
 {
     // ..
 }
+
+use function Pest\Laravel\actingAs as pestActingAs;
+
+function actingAs($user, $driver = null)
+{
+    return pestActingAs($user, $driver);
+}


### PR DESCRIPTION
## Summary
- add `image_path` columns for reviews, comments and messages
- allow uploading images in review, comment and message controllers
- show image previews in message, review and profile views
- ignore Vite when no manifest exists for tests
- add helper in tests to restore `actingAs`

## Testing
- `./vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_684027238e0883289e8c462dd088c5ec