### PR TITLE
Extend review system

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -26,7 +26,9 @@ class CategoryController extends Controller
         $data = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
+            'status' => 'nullable|string',
         ]);
+        $data['slug'] = \Illuminate\Support\Str::slug($data['title']);
         Category::create($data);
         return redirect()->route('admin.categories.index');
     }
@@ -41,7 +43,9 @@ class CategoryController extends Controller
         $data = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
+            'status' => 'nullable|string',
         ]);
+        $data['slug'] = \Illuminate\Support\Str::slug($data['title']);
         $category->update($data);
         return redirect()->route('admin.categories.index');
     }

--- a/app/Http/Controllers/Admin/ReviewController.php
+++ b/app/Http/Controllers/Admin/ReviewController.php
@@ -24,7 +24,11 @@ class ReviewController extends Controller
     public function update(Request $request, Review $review): RedirectResponse
     {
         $data = $request->validate([
+            'title' => 'nullable|string|max:255',
             'content' => 'required|string',
+            'pros' => 'nullable|string',
+            'cons' => 'nullable|string',
+            'status' => 'nullable|string',
             'rating' => 'required|integer|min:1|max:5',
         ]);
         $review->update($data);

--- a/app/Http/Controllers/Admin/ReviewObjectController.php
+++ b/app/Http/Controllers/Admin/ReviewObjectController.php
@@ -30,6 +30,8 @@ class ReviewObjectController extends Controller
             'category_id' => 'required|exists:categories,id',
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
+            'status' => 'nullable|string',
+            'image_path' => 'nullable|string',
         ]);
         $data['slug'] = Str::slug($data['title']);
         ReviewObject::create($data);
@@ -48,6 +50,8 @@ class ReviewObjectController extends Controller
             'category_id' => 'required|exists:categories,id',
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
+            'status' => 'nullable|string',
+            'image_path' => 'nullable|string',
         ]);
         $data['slug'] = Str::slug($data['title']);
         $object->update($data);

--- a/app/Http/Controllers/ReviewObjectController.php
+++ b/app/Http/Controllers/ReviewObjectController.php
@@ -43,17 +43,29 @@ class ReviewObjectController extends Controller
 
         // Валидация
         $validated = $request->validate([
+            'title'   => 'required|string|max:255',
             'content' => 'required|string|min:10|max:2000',
+            'pros'    => 'nullable|string|max:2000',
+            'cons'    => 'nullable|string|max:2000',
             'rating'  => 'required|integer|min:1|max:5',
             'image'   => 'nullable|image|max:2048',
         ]);
+
+        if ($object->reviews()->where('user_id', Auth::id())->exists()) {
+            return redirect()->route('objects.show', ['slug' => $slug])
+                ->with('error', 'Вы уже оставили отзыв на этот объект.');
+        }
 
         // Сохраняем новый отзыв
         $review = new Review([
             'user_id'           => Auth::id(),
             'review_object_id'  => $object->id,
+            'title'            => $validated['title'],
             'content'           => $validated['content'],
+            'pros'              => $validated['pros'] ?? null,
+            'cons'              => $validated['cons'] ?? null,
             'rating'            => $validated['rating'],
+            'status'            => 'pending',
         ]);
         $review->save();
 

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -6,7 +6,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Category extends Model
 {
-    protected $fillable = ['title'];
+    protected $fillable = [
+        'title',
+        'slug',
+        'status',
+    ];
 
     /**
      * Одна категория может иметь много объектов (review_objects).

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -10,9 +10,13 @@ class Review extends Model
     protected $fillable = [
         'user_id',
         'review_object_id',
+        'title',
         'content',
+        'pros',
+        'cons',
         'rating',
         'image_path',
+        'status',
     ];
 
     /**

--- a/app/Models/ReviewObject.php
+++ b/app/Models/ReviewObject.php
@@ -11,6 +11,8 @@ class ReviewObject extends Model
         'title',
         'slug',
         'description',
+        'image_path',
+        'status',
         'avg_rating',
         'reviews_count'
     ];

--- a/database/migrations/2025_06_08_110000_add_slug_status_to_categories_table.php
+++ b/database/migrations/2025_06_08_110000_add_slug_status_to_categories_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->string('slug')->unique()->after('title');
+            $table->string('status')->default('active')->after('slug');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropColumn(['slug', 'status']);
+        });
+    }
+};

--- a/database/migrations/2025_06_08_110001_add_image_status_to_review_objects_table.php
+++ b/database/migrations/2025_06_08_110001_add_image_status_to_review_objects_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('review_objects', function (Blueprint $table) {
+            $table->string('image_path')->nullable()->after('slug');
+            $table->string('status')->default('pending')->after('image_path');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('review_objects', function (Blueprint $table) {
+            $table->dropColumn(['image_path', 'status']);
+        });
+    }
+};

--- a/database/migrations/2025_06_08_110002_add_fields_to_reviews_table.php
+++ b/database/migrations/2025_06_08_110002_add_fields_to_reviews_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->string('title')->nullable()->after('review_object_id');
+            $table->text('pros')->nullable()->after('rating');
+            $table->text('cons')->nullable()->after('pros');
+            $table->string('status')->default('pending')->after('cons');
+            $table->unique(['user_id', 'review_object_id'], 'user_object_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->dropUnique('user_object_unique');
+            $table->dropColumn(['title', 'pros', 'cons', 'status']);
+        });
+    }
+};

--- a/tests/Feature/ReactionTest.php
+++ b/tests/Feature/ReactionTest.php
@@ -8,16 +8,23 @@ use App\Models\Reaction;
 
 it('allows user to like a review', function () {
     $user = User::factory()->create();
-    $category = Category::create(['title' => 'Test']);
+    $category = Category::create([
+        'title' => 'Test',
+        'slug' => 'test',
+        'status' => 'active',
+    ]);
     $object = ReviewObject::create([
         'category_id' => $category->id,
         'title' => 'Obj',
         'slug' => 'obj',
+        'status' => 'approved',
     ]);
     $review = Review::create([
         'user_id' => $user->id,
         'review_object_id' => $object->id,
+        'title' => 'Test',
         'content' => 'text',
+        'status' => 'approved',
         'rating' => 5,
     ]);
 


### PR DESCRIPTION
## Summary
- add fields for slug and status to categories
- add image/status fields on review objects
- expand reviews with title, pros/cons, status, and unique constraint
- adjust controllers and tests for new structure

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68402cd0319483288ac291609153dea6