### PR TITLE
Implement user review objects with hierarchical categories

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -18,7 +18,8 @@ class CategoryController extends Controller
 
     public function create(): View
     {
-        return view('admin.categories.create');
+        $categories = Category::all();
+        return view('admin.categories.create', compact('categories'));
     }
 
     public function store(Request $request): RedirectResponse
@@ -26,6 +27,7 @@ class CategoryController extends Controller
         $data = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
+            'parent_id' => 'nullable|exists:categories,id',
             'status' => 'nullable|string',
         ]);
         $data['slug'] = \Illuminate\Support\Str::slug($data['title']);
@@ -35,7 +37,8 @@ class CategoryController extends Controller
 
     public function edit(Category $category): View
     {
-        return view('admin.categories.edit', compact('category'));
+        $categories = Category::where('id', '!=', $category->id)->get();
+        return view('admin.categories.edit', compact('category', 'categories'));
     }
 
     public function update(Request $request, Category $category): RedirectResponse
@@ -43,6 +46,7 @@ class CategoryController extends Controller
         $data = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
+            'parent_id' => 'nullable|exists:categories,id',
             'status' => 'nullable|string',
         ]);
         $data['slug'] = \Illuminate\Support\Str::slug($data['title']);

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -11,8 +11,10 @@ class HomeController extends Controller
      */
     public function index()
     {
-        // Загружаем все категории вместе с объектами (чтобы не было N+1)
-        $categories = Category::with('objects')->get();
+        // Загружаем только корневые категории с подкатегориями и объектами
+        $categories = Category::with(['children.children', 'objects'])
+            ->whereNull('parent_id')
+            ->get();
 
         return view('home', compact('categories'));
     }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
 use App\Models\Review;
 use App\Models\Comment;
+use App\Models\ReviewObject;
 use App\Models\User;
 use App\Models\Reaction;
 use Illuminate\Support\Facades\DB;
@@ -24,12 +25,16 @@ class ProfileController extends Controller
     {
         $user = $request->user();
 
-        // Загружаем отзывы пользователя (approved = true) вместе с объектами
+        // Загружаем отзывы пользователя вместе с объектами
         $myReviews = Review::where('user_id', $user->id)
-                           ->where('approved', true)
                            ->with('object')
                            ->orderBy('created_at', 'desc')
                            ->get();
+
+        $myObjects = ReviewObject::where('user_id', $user->id)
+                                ->with('category')
+                                ->orderBy('created_at', 'desc')
+                                ->get();
 
         // Загружаем комментарии пользователя вместе с отзывами и объектами
         $myComments = Comment::where('user_id', $user->id)
@@ -37,7 +42,7 @@ class ProfileController extends Controller
                              ->orderBy('created_at', 'desc')
                              ->get();
 
-        return view('profile.edit', compact('user', 'myReviews', 'myComments'));
+        return view('profile.edit', compact('user', 'myReviews', 'myComments', 'myObjects'));
     }
 
     /**
@@ -84,6 +89,11 @@ class ProfileController extends Controller
             ->orderBy('created_at', 'desc')
             ->get();
 
+        $objects = ReviewObject::where('user_id', $user->id)
+            ->with('category')
+            ->orderBy('created_at', 'desc')
+            ->get();
+
         $comments = Comment::where('user_id', $user->id)
             ->with('review.object')
             ->orderBy('created_at', 'desc')
@@ -102,6 +112,6 @@ class ProfileController extends Controller
             ->value('last_activity');
         $lastActivity = $lastActivityTimestamp ? Carbon::createFromTimestamp($lastActivityTimestamp) : null;
 
-        return view('profile.show', compact('user', 'reviews', 'comments', 'reputation', 'followersCount', 'lastActivity'));
+        return view('profile.show', compact('user', 'reviews', 'comments', 'objects', 'reputation', 'followersCount', 'lastActivity'));
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -10,6 +10,7 @@ class Category extends Model
         'title',
         'slug',
         'status',
+        'parent_id',
     ];
 
     /**
@@ -18,5 +19,29 @@ class Category extends Model
     public function objects()
     {
         return $this->hasMany(ReviewObject::class);
+    }
+
+    /**
+     * Parent category relation.
+     */
+    public function parent()
+    {
+        return $this->belongsTo(Category::class, 'parent_id');
+    }
+
+    /**
+     * Children categories relation.
+     */
+    public function children()
+    {
+        return $this->hasMany(Category::class, 'parent_id');
+    }
+
+    /**
+     * Determine if category has no children.
+     */
+    public function isLeaf(): bool
+    {
+        return $this->children()->count() === 0;
     }
 }

--- a/app/Models/ReviewObject.php
+++ b/app/Models/ReviewObject.php
@@ -8,6 +8,7 @@ class ReviewObject extends Model
 {
     protected $fillable = [
         'category_id',
+        'user_id',
         'title',
         'slug',
         'description',
@@ -23,6 +24,14 @@ class ReviewObject extends Model
     public function category()
     {
         return $this->belongsTo(Category::class);
+    }
+
+    /**
+     * Owner of the object.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 
     /**

--- a/database/migrations/2025_06_09_000000_add_parent_id_to_categories.php
+++ b/database/migrations/2025_06_09_000000_add_parent_id_to_categories.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->foreignId('parent_id')->nullable()->after('id')->constrained('categories')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('parent_id');
+        });
+    }
+};

--- a/database/migrations/2025_06_09_000001_add_user_id_to_review_objects.php
+++ b/database/migrations/2025_06_09_000001_add_user_id_to_review_objects.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('review_objects', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->after('category_id')->constrained()->nullOnDelete();
+            $table->unique(['user_id', 'category_id'], 'user_category_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('review_objects', function (Blueprint $table) {
+            $table->dropUnique('user_category_unique');
+            $table->dropConstrainedForeignId('user_id');
+        });
+    }
+};

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -7,6 +7,15 @@
             <input type="text" name="title" class="border rounded w-full" required>
         </div>
         <div>
+            <label class="block">Parent Category</label>
+            <select name="parent_id" class="border rounded w-full">
+                <option value="">-- none --</option>
+                @foreach($categories as $cat)
+                    <option value="{{ $cat->id }}">{{ $cat->title }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
             <label class="block">Description</label>
             <textarea name="description" class="border rounded w-full"></textarea>
         </div>

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -8,6 +8,15 @@
             <input type="text" name="title" class="border rounded w-full" value="{{ $category->title }}" required>
         </div>
         <div>
+            <label class="block">Parent Category</label>
+            <select name="parent_id" class="border rounded w-full">
+                <option value="">-- none --</option>
+                @foreach($categories as $cat)
+                    <option value="{{ $cat->id }}" @selected($category->parent_id == $cat->id)>{{ $cat->title }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
             <label class="block">Description</label>
             <textarea name="description" class="border rounded w-full">{{ $category->description }}</textarea>
         </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -16,59 +16,9 @@
             </div>
         @endif
 
-        {{-- Перебираем каждую категорию --}}
+        {{-- Древовидный вывод категорий --}}
         @foreach ($categories as $category)
-            <div class="mb-8">
-                {{-- Заголовок категории --}}
-                <h3 class="text-2xl font-semibold text-gray-800 mb-4">{{ $category->title }}</h3>
-
-                @if ($category->objects->isEmpty())
-                    {{-- Если у категории нет объектов --}}
-                    <p class="text-gray-500 ml-4">В данной категории пока нет объектов.</p>
-                @else
-                    {{-- Сетка карточек объектов --}}
-                    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-                        @foreach ($category->objects as $object)
-                            <div class="bg-white shadow rounded-lg overflow-hidden">
-                                <div class="p-4">
-                                    {{-- Название объекта --}}
-                                    <h4 class="text-lg font-medium text-gray-800">
-                                        <a href="{{ route('objects.show', ['slug' => $object->slug]) }}"
-                                           class="text-indigo-600 hover:text-indigo-800">
-                                            {{ $object->title }}
-                                        </a>
-                                    </h4>
-
-                                    {{-- Краткое описание --}}
-                                    <p class="text-gray-600 text-sm mt-2">
-                                        {{ \Illuminate\Support\Str::limit($object->description, 100) }}
-                                    </p>
-
-                                    {{-- Средний рейтинг (если хранится в базе) --}}
-                                    @if(isset($object->avg_rating) && $object->reviews_count !== null)
-                                        <div class="flex items-center text-sm text-gray-700 mt-2">
-                                            <span class="font-semibold">Рейтинг:</span>
-                                            <span class="ml-2 text-yellow-500">
-                                                {{ number_format($object->avg_rating, 1) }} / 5
-                                            </span>
-                                            <span class="ml-2 text-gray-500">({{ $object->reviews_count }} отзывов)</span>
-                                        </div>
-                                    @endif
-
-                                    {{-- Кнопка “Подробнее” --}}
-                                    <div class="mt-4">
-                                        <a href="{{ route('objects.show', ['slug' => $object->slug]) }}"
-                                           class="inline-block px-3 py-1 bg-indigo-600 text-white 
-                                                  text-xs font-semibold rounded hover:bg-indigo-700">
-                                            Подробнее
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                        @endforeach
-                    </div>
-                @endif
-            </div>
+            @include('home.category-tree', ['category' => $category, 'level' => 0])
         @endforeach
     </div>
 </x-app-layout>

--- a/resources/views/home/category-tree.blade.php
+++ b/resources/views/home/category-tree.blade.php
@@ -1,0 +1,24 @@
+<div class="ml-{{ $level * 4 }} mb-4">
+    <h4 class="text-xl font-semibold text-gray-800">{{ $category->title }}</h4>
+    @if($category->children->isNotEmpty())
+        @foreach($category->children as $child)
+            @include('home.category-tree', ['category' => $child, 'level' => $level + 1])
+        @endforeach
+    @endif
+    @if($category->objects->isNotEmpty())
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 mt-2">
+            @foreach ($category->objects as $object)
+                <div class="bg-white shadow rounded-lg overflow-hidden">
+                    <div class="p-4">
+                        <h5 class="text-lg font-medium">
+                            <a href="{{ route('objects.show', $object->slug) }}" class="text-indigo-600 hover:text-indigo-800">
+                                {{ $object->title }}
+                            </a>
+                        </h5>
+                        <p class="text-gray-600 text-sm mt-2">{{ \Illuminate\Support\Str::limit($object->description, 100) }}</p>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/objects/create.blade.php
+++ b/resources/views/objects/create.blade.php
@@ -1,0 +1,75 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Создать объект и отзыв') }}
+        </h2>
+    </x-slot>
+
+    <div class="max-w-3xl mx-auto py-8">
+        @if ($errors->any())
+            <div class="bg-red-50 border border-red-200 text-red-700 rounded p-4 mb-4">
+                <ul class="list-disc list-inside">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        <form action="{{ route('objects.store') }}" method="POST" enctype="multipart/form-data" class="space-y-6">
+            @csrf
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Категория</label>
+                <select name="category_id" class="mt-1 block w-full border-gray-300 rounded-md" required>
+                    @foreach ($categories as $category)
+                        @include('objects.partials.option', ['category' => $category, 'level' => 0])
+                    @endforeach
+                </select>
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Название объекта</label>
+                <input type="text" name="title" class="mt-1 block w-full border-gray-300 rounded-md" required>
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Описание</label>
+                <textarea name="description" class="mt-1 block w-full border-gray-300 rounded-md" rows="4"></textarea>
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Изображение объекта</label>
+                <input type="file" name="object_image" accept="image/*">
+            </div>
+
+            <hr class="my-6">
+
+            <h3 class="text-lg font-semibold">Ваш отзыв</h3>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Оценка</label>
+                <select name="rating" class="mt-1 block w-24 border-gray-300 rounded-md" required>
+                    @for ($i = 5; $i >= 1; $i--)
+                        <option value="{{ $i }}">{{ $i }}</option>
+                    @endfor
+                </select>
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Текст отзыва</label>
+                <textarea name="review_content" rows="5" class="mt-1 block w-full border-gray-300 rounded-md" required></textarea>
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Плюсы</label>
+                <textarea name="pros" rows="2" class="mt-1 block w-full border-gray-300 rounded-md"></textarea>
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Минусы</label>
+                <textarea name="cons" rows="2" class="mt-1 block w-full border-gray-300 rounded-md"></textarea>
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Изображение к отзыву</label>
+                <input type="file" name="review_image" accept="image/*">
+            </div>
+
+            <div class="flex justify-end">
+                <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-md">Создать</button>
+            </div>
+        </form>
+    </div>
+</x-app-layout>

--- a/resources/views/objects/partials/option.blade.php
+++ b/resources/views/objects/partials/option.blade.php
@@ -1,0 +1,8 @@
+<option value="{{ $category->id }}" @if(old('category_id')===$category->id) selected @endif>
+    {{ str_repeat('— ', $level) }}{{ $category->title }}
+</option>
+@if ($category->children)
+    @foreach ($category->children as $child)
+        @include('objects.partials.option', ['category' => $child, 'level' => $level+1])
+    @endforeach
+@endif

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -15,6 +15,9 @@
                     <a href="#tab-main" class="tab-link text-gray-600 hover:text-indigo-600 font-medium" data-tab="main">
                         Основное
                     </a>
+                    <a href="#tab-objects" class="tab-link text-gray-600 hover:text-indigo-600 font-medium" data-tab="objects">
+                        Мои объекты ({{ $myObjects->count() }})
+                    </a>
                     <a href="#tab-reviews" class="tab-link text-gray-600 hover:text-indigo-600 font-medium" data-tab="reviews">
                         Мои отзывы ({{ $myReviews->count() }})
                     </a>
@@ -80,7 +83,24 @@
                     </form>
                 </div>
 
-                {{-- 2. Мои отзывы --}}
+                {{-- 2. Мои объекты --}}
+                <div id="tab-objects" class="tab-content hidden space-y-4">
+                    @forelse ($myObjects as $object)
+                        <div class="bg-gray-50 p-4 rounded-md border">
+                            <div class="flex items-center justify-between">
+                                <a href="{{ route('objects.show', $object->slug) }}" class="text-indigo-600 hover:underline font-medium">
+                                    {{ $object->title }}
+                                </a>
+                                <span class="text-gray-500 text-sm">{{ $object->created_at->format('d.m.Y') }}</span>
+                            </div>
+                            <p class="mt-1 text-gray-700">Категория: {{ $object->category?->title }}</p>
+                        </div>
+                    @empty
+                        <p class="text-gray-600 italic">Вы ещё не создали ни одного объекта.</p>
+                    @endforelse
+                </div>
+
+                {{-- 3. Мои отзывы --}}
                 <div id="tab-reviews" class="tab-content hidden space-y-4">
                     @forelse ($myReviews as $review)
                         <div class="bg-gray-50 p-4 rounded-md border">

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -45,6 +45,7 @@
         <div class="bg-white shadow rounded-lg">
             <nav class="border-b flex space-x-8 px-6 pt-4">
                 <a href="#tab-about" class="tab-link text-gray-600 hover:text-indigo-600 font-medium" data-tab="about">Обо мне</a>
+                <a href="#tab-objects" class="tab-link text-gray-600 hover:text-indigo-600 font-medium" data-tab="objects">Объекты ({{ $objects->count() }})</a>
                 <a href="#tab-reviews" class="tab-link text-gray-600 hover:text-indigo-600 font-medium" data-tab="reviews">Отзывы ({{ $reviews->count() }})</a>
                 <a href="#tab-comments" class="tab-link text-gray-600 hover:text-indigo-600 font-medium" data-tab="comments">Комментарии ({{ $comments->count() }})</a>
                 @auth
@@ -60,6 +61,21 @@
             <div class="p-6">
                 <div id="tab-about" class="tab-content">
                     <p class="text-gray-700">{{ $user->about ?? 'Пользователь ещё не рассказал о себе.' }}</p>
+                </div>
+                <div id="tab-objects" class="tab-content hidden space-y-4">
+                    @forelse($objects as $object)
+                        <div class="bg-gray-50 p-4 rounded-md border">
+                            <div class="flex items-center justify-between">
+                                <a href="{{ route('objects.show', $object->slug) }}" class="text-indigo-600 hover:underline font-medium">
+                                    {{ $object->title }}
+                                </a>
+                                <span class="text-gray-500 text-sm">{{ $object->created_at->format('d.m.Y') }}</span>
+                            </div>
+                            <p class="mt-1 text-gray-700">Категория: {{ $object->category?->title }}</p>
+                        </div>
+                    @empty
+                        <p class="text-gray-600 italic">Объектов пока нет.</p>
+                    @endforelse
                 </div>
                 <div id="tab-reviews" class="tab-content hidden space-y-4">
                     @forelse($reviews as $review)

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,10 @@ Route::middleware(['auth'])->group(function () {
         return view('dashboard');
     })->name('dashboard');
 
+    // Создание собственного объекта и отзыва
+    Route::get('/objects/create', [ReviewObjectController::class, 'create'])->name('objects.create');
+    Route::post('/objects', [ReviewObjectController::class, 'store'])->name('objects.store');
+
     // 7.2) Профиль пользователя (редактирование, просмотр отзывов/комментариев)
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
## Summary
- add parent_id to categories and user_id to review_objects
- support recursive category relations and check leaf categories
- let users create review objects and initial reviews
- display category tree and user-created objects in profiles
- update admin forms to manage parent categories

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684030cccc3483289495945e586160be