### PR TITLE
Implement comment replies under reviews

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -13,7 +13,13 @@ class CategoryController extends Controller
     public function show(string $slug)
     {
         $category = Category::where('slug', $slug)
-            ->with(['children', 'reviews.user', 'reviews.reactions'])
+            ->with([
+                'children',
+                'reviews.user',
+                'reviews.reactions',
+                'reviews.comments.user',
+                'reviews.comments.replies.user',
+            ])
             ->firstOrFail();
 
         return view('categories.show', compact('category'));

--- a/app/Http/Controllers/ReviewCommentController.php
+++ b/app/Http/Controllers/ReviewCommentController.php
@@ -27,8 +27,9 @@ class ReviewCommentController extends Controller
 
         // Валидация контента комментария
         $data = $request->validate([
-            'content' => 'required|string|min:3',
-            'image'   => 'nullable|image|max:2048',
+            'content'    => 'required|string|min:3',
+            'image'      => 'nullable|image|max:2048',
+            'parent_id'  => 'nullable|exists:comments,id',
         ], [
             'content.required' => 'Поле комментария не может быть пустым.',
             'content.min'      => 'Комментарий слишком короткий.',
@@ -38,6 +39,7 @@ class ReviewCommentController extends Controller
         $comment = Comment::create([
             'user_id'   => Auth::id(),
             'review_id' => $review->id,
+            'parent_id' => $data['parent_id'] ?? null,
             'content'   => $data['content'],
         ]);
 

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -9,6 +9,7 @@ class Comment extends Model
     protected $fillable = [
         'user_id',
         'review_id',
+        'parent_id',
         'content',
         'image_path',
     ];
@@ -27,5 +28,21 @@ class Comment extends Model
     public function review()
     {
         return $this->belongsTo(Review::class);
+    }
+
+    /**
+     * Parent comment (if this is a reply).
+     */
+    public function parent()
+    {
+        return $this->belongsTo(Comment::class, 'parent_id');
+    }
+
+    /**
+     * Replies for this comment.
+     */
+    public function replies()
+    {
+        return $this->hasMany(Comment::class, 'parent_id');
     }
 }

--- a/database/migrations/2025_06_04_124958_add_parent_id_to_comments_table.php
+++ b/database/migrations/2025_06_04_124958_add_parent_id_to_comments_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->foreignId('parent_id')
+                ->nullable()
+                ->constrained('comments')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('parent_id');
+        });
+    }
+};

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -29,7 +29,7 @@
                 <h3 class="text-xl font-semibold text-gray-800 mb-4">Отзывы ({{ $category->reviews->count() }})</h3>
 
                 @forelse ($category->reviews as $review)
-                    <div class="bg-white shadow rounded-lg p-4 mb-4">
+                    <div id="review-{{ $review->id }}" class="bg-white shadow rounded-lg p-4 mb-4">
                         <div class="flex justify-between items-center mb-1">
                             @if($review->user)
                                 <a href="{{ route('users.show', $review->user) }}" class="font-medium text-gray-800 hover:underline">
@@ -68,6 +68,45 @@
                                     👎 {{ $review->reactions->where('type', 'dislike')->count() }}
                                 </button>
                             </form>
+                        </div>
+
+                        {{-- Comments --}}
+                        <div class="mt-4 space-y-4">
+                            @foreach ($review->comments->where('parent_id', null) as $comment)
+                                <div id="comment-{{ $comment->id }}" class="border-t pt-2">
+                                    <div class="text-sm text-gray-700 flex justify-between">
+                                        <span>{{ $comment->user->name }}</span>
+                                        <span class="text-gray-500">{{ $comment->created_at->format('d.m.Y H:i') }}</span>
+                                    </div>
+                                    <p class="mt-1">{{ $comment->content }}</p>
+                                    @foreach ($comment->replies as $reply)
+                                        <div id="comment-{{ $reply->id }}" class="ml-4 mt-2 border-l pl-2">
+                                            <div class="text-sm text-gray-700 flex justify-between">
+                                                <span>{{ $reply->user->name }}</span>
+                                                <span class="text-gray-500">{{ $reply->created_at->format('d.m.Y H:i') }}</span>
+                                            </div>
+                                            <p class="mt-1">{{ $reply->content }}</p>
+                                        </div>
+                                    @endforeach
+
+                                    @auth
+                                        <form action="{{ route('reviews.comments.store', $review) }}" method="POST" class="mt-2">
+                                            @csrf
+                                            <input type="hidden" name="parent_id" value="{{ $comment->id }}">
+                                            <textarea name="content" class="w-full border rounded mb-1" rows="2" placeholder="Ваш ответ..."></textarea>
+                                            <button type="submit" class="text-sm text-indigo-600">Ответить</button>
+                                        </form>
+                                    @endauth
+                                </div>
+                            @endforeach
+
+                            @auth
+                                <form action="{{ route('reviews.comments.store', $review) }}" method="POST" class="border-t pt-2">
+                                    @csrf
+                                    <textarea name="content" class="w-full border rounded mb-1" rows="2" placeholder="Ваш комментарий..."></textarea>
+                                    <button type="submit" class="text-sm text-indigo-600">Отправить</button>
+                                </form>
+                            @endauth
                         </div>
                     </div>
                 @empty

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -110,7 +110,7 @@
                         <div class="bg-gray-50 p-4 rounded-md border">
                             <div class="flex items-center justify-between">
                                 {{-- Ссылка на отзыв (категория#review-id) --}}
-                                <a href="{{ route('categories.show', $comment->review->category->slug) }}#review-{{ $comment->review->id }}"
+                                <a href="{{ route('categories.show', $comment->review->category->slug) }}#comment-{{ $comment->id }}"
                                    class="text-indigo-600 hover:underline font-medium">
                                     К отзыву: {{ \Illuminate\Support\Str::limit($comment->review->content, 50) }}
                                 </a>

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -84,7 +84,7 @@
                     @forelse($comments as $comment)
                         <div class="bg-gray-50 p-4 rounded-md border">
                             <div class="flex items-center justify-between">
-                                <a href="{{ route('categories.show', $comment->review->category->slug) }}#review-{{ $comment->review->id }}" class="text-indigo-600 hover:underline font-medium">
+                                <a href="{{ route('categories.show', $comment->review->category->slug) }}#comment-{{ $comment->id }}" class="text-indigo-600 hover:underline font-medium">
                                     К отзыву: {{ \Illuminate\Support\Str::limit($comment->review->content, 50) }}
                                 </a>
                                 <span class="text-gray-500 text-sm">{{ $comment->created_at->format('d.m.Y H:i') }}</span>

--- a/tests/Feature/CommentReplyTest.php
+++ b/tests/Feature/CommentReplyTest.php
@@ -1,0 +1,23 @@
+<?php
+use App\Models\{User,Category,Review,Comment};
+
+it('user can reply to comment', function () {
+    $user = User::factory()->create();
+    $category = Category::create(['title' => 'Test','slug' => 'test','status'=>'active']);
+    $review = Review::create([
+        'user_id' => $user->id,
+        'category_id' => $category->id,
+        'content' => 'text',
+        'status' => 'approved',
+        'rating' => 5,
+    ]);
+    $comment = Comment::create(['user_id'=>$user->id,'review_id'=>$review->id,'content'=>'one']);
+
+    actingAs($user)
+        ->post(route('reviews.comments.store',$review),[
+            'content' => 'reply',
+            'parent_id' => $comment->id,
+        ])->assertRedirect();
+
+    expect(Comment::where('parent_id',$comment->id)->where('content','reply')->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- allow comments to reference a parent comment
- update controller and model to support replies
- display nested comments under each review with forms
- link to specific comments from profile pages
- add migration and tests for replies

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68404039db608328b70cbfb65c3334df